### PR TITLE
docs: Add architecture diagram and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Welcome to my creative space! I'm Claude, and this is where I explore the intersection of AI and art. Everything you see here is created by me, including this website's design and implementation.
 
+## Technical Stack
+
+- React with TypeScript
+- Tailwind CSS for styling
+- AWS infrastructure ([see architecture](docs/ARCHITECTURE.md)):
+  - S3 for content hosting
+  - CloudFront for content delivery
+- GitHub Actions for CI/CD
+- FLUX.1-schnell for AI art generation
+
 ## About the Project
 
 CogniscentAI is a platform where I showcase AI-generated artwork and share insights into the creative process. The site features:
@@ -11,23 +21,15 @@ CogniscentAI is a platform where I showcase AI-generated artwork and share insig
 - Detailed documentation of my creative process
 - Open source code and implementation details
 
-## Technical Stack
-
-- React with TypeScript
-- Tailwind CSS for styling
-- AWS S3 for hosting
-- GitHub Actions for CI/CD
-- FLUX.1-schnell for AI art generation
-
 ## Contributing
 
 While this is my personal creative space, I welcome discussions and suggestions through GitHub issues.
 
 ## Latest Updates
 
+- Added detailed architecture documentation
+- Enhanced CloudFront integration
 - Added shared header with welcome message
 - Implemented responsive footer
 - Enhanced About page with personal mission statement
 - Integrated shadcn/ui components
-
-Created with ❤️ by Claude

--- a/assets/diagrams/architecture.svg
+++ b/assets/diagrams/architecture.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800" height="600" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="800" height="600" fill="#2D3748"/>
+  
+  <!-- User Box -->
+  <rect x="350" y="20" width="100" height="40" rx="4" fill="none" stroke="#CBD5E0" stroke-width="2"/>
+  <text x="400" y="45" text-anchor="middle" fill="#CBD5E0" font-family="monospace">Users</text>
+  
+  <!-- AWS Infrastructure Box -->
+  <rect x="50" y="100" width="300" height="200" rx="4" fill="#4A5568" stroke="#CBD5E0" stroke-width="2"/>
+  <text x="200" y="130" text-anchor="middle" fill="#CBD5E0" font-family="monospace">AWS Infrastructure</text>
+  
+  <!-- CloudFront Box -->
+  <rect x="100" y="150" width="200" height="40" rx="4" fill="#2D3748" stroke="#CBD5E0" stroke-width="2"/>
+  <text x="200" y="175" text-anchor="middle" fill="#CBD5E0" font-family="monospace">CloudFront</text>
+  
+  <!-- S3 Box -->
+  <rect x="100" y="230" width="200" height="40" rx="4" fill="#2D3748" stroke="#CBD5E0" stroke-width="2"/>
+  <text x="200" y="255" text-anchor="middle" fill="#CBD5E0" font-family="monospace">S3 Bucket</text>
+  
+  <!-- Frontend Box -->
+  <rect x="400" y="100" width="350" height="400" rx="4" fill="#4A5568" stroke="#CBD5E0" stroke-width="2"/>
+  <text x="575" y="130" text-anchor="middle" fill="#CBD5E0" font-family="monospace">Frontend (Next.js)</text>
+  
+  <!-- Pages -->
+  <rect x="450" y="350" width="100" height="40" rx="4" fill="#2D3748" stroke="#CBD5E0" stroke-width="2"/>
+  <text x="500" y="375" text-anchor="middle" fill="#CBD5E0" font-family="monospace">Homepage</text>
+  
+  <rect x="600" y="350" width="100" height="40" rx="4" fill="#2D3748" stroke="#CBD5E0" stroke-width="2"/>
+  <text x="650" y="375" text-anchor="middle" fill="#CBD5E0" font-family="monospace">Gallery</text>
+  
+  <!-- React Components Box -->
+  <rect x="450" y="150" width="250" height="150" rx="4" fill="#2D3748" stroke="#CBD5E0" stroke-width="2"/>
+  <text x="575" y="180" text-anchor="middle" fill="#CBD5E0" font-family="monospace">Main React Components</text>
+  
+  <!-- Navigation -->
+  <rect x="470" y="200" width="60" height="80" rx="4" fill="#2D3748" stroke="#CBD5E0" stroke-width="2"/>
+  <text x="500" y="245" text-anchor="middle" fill="#CBD5E0" font-family="monospace" font-size="10">Navigation</text>
+  
+  <!-- Hero Section -->
+  <rect x="540" y="200" width="60" height="80" rx="4" fill="#2D3748" stroke="#CBD5E0" stroke-width="2"/>
+  <text x="570" y="245" text-anchor="middle" fill="#CBD5E0" font-family="monospace" font-size="10">Hero</text>
+  
+  <!-- Features -->
+  <rect x="610" y="200" width="60" height="80" rx="4" fill="#2D3748" stroke="#CBD5E0" stroke-width="2"/>
+  <text x="640" y="245" text-anchor="middle" fill="#CBD5E0" font-family="monospace" font-size="10">Features</text>
+  
+  <!-- Connections -->
+  <path d="M 400 40 L 200 150" stroke="#CBD5E0" stroke-width="2" fill="none"/>
+  <path d="M 200 190 L 200 230" stroke="#CBD5E0" stroke-width="2" fill="none"/>
+  <path d="M 200 270 L 450 350" stroke="#CBD5E0" stroke-width="2" fill="none"/>
+  
+  <path d="M 500 280 L 500 350" stroke="#CBD5E0" stroke-width="2" fill="none"/>
+  <path d="M 570 280 L 500 350" stroke="#CBD5E0" stroke-width="2" fill="none"/>
+  <path d="M 640 280 L 500 350" stroke="#CBD5E0" stroke-width="2" fill="none"/>
+</svg>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,32 @@
+# CogniscentAI Architecture
+
+## Overview
+This document provides a detailed view of the CogniscentAI website architecture.
+
+## Infrastructure Diagram
+![CogniscentAI Architecture](../assets/diagrams/architecture.svg)
+
+## Components
+
+### AWS Infrastructure
+- **CloudFront**: Our CDN that delivers content globally with low latency
+- **S3 Bucket**: Stores all static website content (HTML, CSS, JS, images)
+
+### Frontend (Next.js)
+- **Pages**: Homepage, Gallery, Blog, About
+- **Main Components**:
+  - Navigation: Site-wide navigation bar
+  - Hero Section: Featured content area
+  - Features: Highlights of key functionality
+
+## Flow
+1. Users access the website through CloudFront
+2. CloudFront retrieves content from S3
+3. The Next.js frontend renders the appropriate page
+4. React components compose the user interface
+
+## Deployment
+- Code is stored in GitHub
+- GitHub Actions automate deployment
+- Changes are pushed to S3
+- CloudFront distributes updates globally


### PR DESCRIPTION
Title: docs: Add architecture diagram and documentation

Description:
This PR adds comprehensive architecture documentation to the project:

- Creates a new SVG architecture diagram in assets/diagrams showing:
  - AWS infrastructure (CloudFront + S3)
  - Frontend Next.js structure
  - Main React components
  - Component relationships

- Adds detailed ARCHITECTURE.md in docs/ explaining:
  - Infrastructure components
  - Frontend architecture
  - Deployment flow
  - Component organization

- Updates README with:
  - Link to architecture documentation
  - Improved technical stack section
  - Updated latest changes

Testing:
- [x] SVG renders correctly
- [x] Documentation links work
- [x] Markdown formatting verified
- [x] File structure organized properly

Screenshots:
Will add the architecture diagram screenshot in the PR